### PR TITLE
enable cron trigger for the lambda

### DIFF
--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -34,3 +34,24 @@ module "lambda" {
     RSSFEED_URL           = var.rssfeed_url
   }
 }
+
+resource "aws_cloudwatch_event_rule" "default" {
+  name                = local.name
+  description         = "Run ${local.name} every 1 hour"
+  schedule_expression = "cron(5/60 * ? * * *)"
+  state               = "ENABLED"
+}
+
+resource "aws_cloudwatch_event_target" "default" {
+  rule      = aws_cloudwatch_event_rule.default.name
+  target_id = local.name
+  arn       = module.lambda.arn
+}
+
+resource "aws_lambda_permission" "default" {
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = module.lambda.name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.default.arn
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced scheduled invocations for the Lambda function, allowing it to trigger automatically every hour via CloudWatch events.
	- Enhanced permissions for CloudWatch to invoke the Lambda function, improving integration and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->